### PR TITLE
Componente de lista #12

### DIFF
--- a/src/components/DeveloperList/DeveloperList.tsx
+++ b/src/components/DeveloperList/DeveloperList.tsx
@@ -1,0 +1,39 @@
+import React from "react"
+
+type Props = {
+  title?: string
+  subtitle?: string
+  list: {
+    name: string
+    initials: string
+    image: string
+    summary: string
+    skills: string
+    linkedin?: string
+    github?: string
+    twitter?: string
+    webpage?: string
+  }[]
+}
+
+const DeveloperList: React.FC<Props> = ({ title, subtitle, list }) => {
+  return (
+    <div>
+      <h2>{title}</h2>
+      <h5>{subtitle}</h5>
+      {list.length > 0 ? (
+        list.map(element => (
+          <div key={element.name}>
+            <h2>{element.name}</h2>
+            <h3>{element.summary}</h3>
+            <h4>{element.skills}</h4>
+          </div>
+        ))
+      ) : (
+        <p>Nothing to show</p>
+      )}
+    </div>
+  )
+}
+
+export default DeveloperList

--- a/src/components/__tests__/DeveloperList.test.tsx
+++ b/src/components/__tests__/DeveloperList.test.tsx
@@ -1,0 +1,75 @@
+import * as React from "react"
+import { render } from "@testing-library/react"
+import renderer from "react-test-renderer"
+
+import DeveloperList from "../DeveloperList/DeveloperList"
+
+describe("DeveloperList", () => {
+  it("renders title with empty list", () => {
+    const listTitle = "Devs DO"
+    const { getByText } = render(<DeveloperList title={listTitle} list={[]} />)
+
+    const title = getByText(listTitle)
+
+    expect(title).toBeInTheDocument()
+  })
+
+  it("renders subtitle with empty list", () => {
+    const listSubtitle = "This is a test"
+    const { getByText } = render(
+      <DeveloperList subtitle={listSubtitle} list={[]} />
+    )
+
+    const subtitle = getByText(listSubtitle)
+
+    expect(subtitle).toBeInTheDocument()
+  })
+
+  it("renders list", () => {
+    const data = [
+      {
+        name: "Juan Perez",
+        initials: "JP",
+        image:
+          "https://upload.wikimedia.org/wikipedia/commons/3/3f/Juan_Perez_July_2013.jpg",
+        summary: "Developer God",
+        skills: "All of them"
+      }
+    ]
+    const { getByText } = render(<DeveloperList list={data} />)
+
+    const name = getByText(data[0].name)
+
+    expect(name).toBeInTheDocument()
+  })
+
+  it("renders empty list", () => {
+    const emptyMessage = "Nothing to show"
+    const { getByText } = render(<DeveloperList list={[]} />)
+
+    const message = getByText(emptyMessage)
+
+    expect(message).toBeInTheDocument()
+  })
+
+  it("renders correctly", () => {
+    const listTitle = "Devs DO"
+    const listSubtitle = "This is a test"
+    const data = [
+      {
+        name: "Juan Perez",
+        initials: "JP",
+        image:
+          "https://upload.wikimedia.org/wikipedia/commons/3/3f/Juan_Perez_July_2013.jpg",
+        summary: "Developer God",
+        skills: "All of them"
+      }
+    ]
+    const tree = renderer
+      .create(
+        <DeveloperList title={listTitle} subtitle={listSubtitle} list={data} />
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/components/__tests__/__snapshots__/DeveloperList.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/DeveloperList.test.tsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DeveloperList renders correctly 1`] = `
+<div>
+  <h2>
+    Devs DO
+  </h2>
+  <h5>
+    This is a test
+  </h5>
+  <div>
+    <h2>
+      Juan Perez
+    </h2>
+    <h3>
+      Developer God
+    </h3>
+    <h4>
+      All of them
+    </h4>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Esto debería resolver el problema #12 

 - Agregar componente de lista para desarrolladores.
 - Recibe mediante `props` un **título**, **subtítulo**, y una **lista de desarrolladores**.
> Nota: Tome en consideración la estructura del `json` del otro proyecto por el momento.